### PR TITLE
nicintel: add I350 support

### DIFF
--- a/nicintel_eeprom.c
+++ b/nicintel_eeprom.c
@@ -27,6 +27,9 @@
  * 8.4.3: EEPROM-Mode Read Register
  * 8.4.6: EEPROM-Mode Write Register
  * Write process inspired on kernel e1000_i210.c
+ *
+ * Intel I350 Gigabit controller Datasheet
+ * https://www.intel.com/content/dam/www/public/us/en/documents/datasheets/ethernet-controller-i350-datasheet.pdf
  */
 
 #include <stdlib.h>
@@ -75,8 +78,6 @@ static uint8_t *nicintel_eebar;
 static struct pci_dev *nicintel_pci;
 static bool done_i20_write = false;
 
-#define UNPROG_DEVICE 0x1509
-
 /*
  * Warning: is_i210() below makes assumptions on these PCI ids.
  *          It may have to be updated when this list is extended.
@@ -87,7 +88,7 @@ const struct dev_entry nics_intel_ee[] = {
 	{PCI_VENDOR_ID_INTEL, 0x1510, NT , "Intel", "82580 Quad Gigabit Ethernet Controller (Backplane)"},
 	{PCI_VENDOR_ID_INTEL, 0x1511, NT , "Intel", "82580 Quad Gigabit Ethernet Controller (Ext. PHY)"},
 	{PCI_VENDOR_ID_INTEL, 0x1511, NT , "Intel", "82580 Dual Gigabit Ethernet Controller (Copper)"},
-	{PCI_VENDOR_ID_INTEL, UNPROG_DEVICE, OK, "Intel", "Unprogrammed 82580 Quad/Dual Gigabit Ethernet Controller"},
+	{PCI_VENDOR_ID_INTEL, 0x1509, OK, "Intel", "Unprogrammed 82580 Quad/Dual Gigabit Ethernet Controller"},
 	{PCI_VENDOR_ID_INTEL, 0x1531, NT, "Intel", "I210 Gigabit Network Connection Unprogrammed"},
 	{PCI_VENDOR_ID_INTEL, 0x1532, NT, "Intel", "I211 Gigabit Network Connection Unprogrammed"},
 	{PCI_VENDOR_ID_INTEL, 0x1533, OK, "Intel", "I210 Gigabit Network Connection"},
@@ -95,8 +96,25 @@ const struct dev_entry nics_intel_ee[] = {
 	{PCI_VENDOR_ID_INTEL, 0x1537, NT, "Intel", "I210 Gigabit Network Connection SERDES Backplane"},
 	{PCI_VENDOR_ID_INTEL, 0x1538, NT, "Intel", "I210 Gigabit Network Connection SGMII"},
 	{PCI_VENDOR_ID_INTEL, 0x1539, NT, "Intel", "I211 Gigabit Network Connection"},
+	{PCI_VENDOR_ID_INTEL, 0x151f, OK, "Intel", "I350 Gigabit Network Connection Unprogrammed"},
+	{PCI_VENDOR_ID_INTEL, 0x1521, OK, "Intel", "I350 Gigabit Network Connection Copper"},
+	{PCI_VENDOR_ID_INTEL, 0x1522, NT, "Intel", "I350 Gigabit Network Connection Fiber"},
+	{PCI_VENDOR_ID_INTEL, 0x1523, NT, "Intel", "I350 Gigabit Network Connection 1000BASE-KX / 1000BASE-BX backplane"},
+	{PCI_VENDOR_ID_INTEL, 0x1522, NT, "Intel", "I350 Gigabit Network Connection External SGMII PHY"},
 	{0},
 };
+
+static inline bool is_unprog_device(uint16_t device_id)
+{
+	switch (device_id)
+	{
+		case 0x1509: // Unprogrammed 82580 Quad/Dual Gigabit Ethernet Controller
+		case 0x151f: // I350 Gigabit Network Connection Unprogrammed
+			return true;
+		default:
+			return false;
+	}
+}
 
 static inline bool is_i210(uint16_t device_id)
 {
@@ -118,7 +136,7 @@ static int nicintel_ee_probe_i210(struct flashctx *flash)
 
 static int nicintel_ee_probe_82580(struct flashctx *flash)
 {
-	if (nicintel_pci->device_id == UNPROG_DEVICE)
+	if (is_unprog_device(nicintel_pci->device_id))
 		flash->chip->total_size = 16; /* Fall back to minimum supported size. */
 	else {
 		uint32_t tmp = pci_mmio_readl(nicintel_eebar + EEC);
@@ -456,7 +474,7 @@ int nicintel_ee_init(void)
 	if (!dev)
 		return 1;
 
-	uint32_t io_base_addr = pcidev_readbar(dev, PCI_BASE_ADDRESS_0);
+	uintptr_t io_base_addr = pcidev_readbar(dev, PCI_BASE_ADDRESS_0);
 	if (!io_base_addr)
 		return 1;
 
@@ -466,7 +484,7 @@ int nicintel_ee_init(void)
 			return 1;
 
 		nicintel_pci = dev;
-		if ((dev->device_id != UNPROG_DEVICE)) {
+		if (!is_unprog_device(dev->device_id)) {
 			uint32_t eec = pci_mmio_readl(nicintel_eebar + EEC);
 
 			/* C.f. 3.3.1.5 for the detection mechanism (maybe? contradicting

--- a/nicintel_spi.c
+++ b/nicintel_spi.c
@@ -28,6 +28,9 @@
  *
  * Intel 82599 10 GbE Controller Datasheet (331520)
  * http://www.intel.com/content/dam/www/public/us/en/documents/datasheets/82599-10-gbe-controller-datasheet.pdf
+ *
+ * Intel I350 Gigabit controller Datasheet
+ * https://www.intel.com/content/dam/www/public/us/en/documents/datasheets/ethernet-controller-i350-datasheet.pdf
  */
 
 #include <stdlib.h>
@@ -104,6 +107,11 @@ const struct dev_entry nics_intel_spi[] = {
 	{PCI_VENDOR_ID_INTEL, 0x1538, NT, "Intel", "I210 Gigabit Network Connection SGMII"},
 	{PCI_VENDOR_ID_INTEL, 0x1539, NT, "Intel", "I211 Gigabit Network Connection"},
 
+	{PCI_VENDOR_ID_INTEL, 0x151f, NT, "Intel", "I350 Gigabit Network Connection Unprogrammed"},
+	{PCI_VENDOR_ID_INTEL, 0x1521, NT, "Intel", "I350 Gigabit Network Connection Copper"},
+	{PCI_VENDOR_ID_INTEL, 0x1522, NT, "Intel", "I350 Gigabit Network Connection Fiber"},
+	{PCI_VENDOR_ID_INTEL, 0x1523, NT, "Intel", "I350 Gigabit Network Connection 1000BASE-KX / 1000BASE-BX backplane"},
+	{PCI_VENDOR_ID_INTEL, 0x1522, NT, "Intel", "I350 Gigabit Network Connection External SGMII PHY"},
 	{0},
 };
 
@@ -252,7 +260,7 @@ int nicintel_spi_init(void)
 	if (!dev)
 		return 1;
 
-	uint32_t io_base_addr = pcidev_readbar(dev, PCI_BASE_ADDRESS_0);
+	uintptr_t io_base_addr = pcidev_readbar(dev, PCI_BASE_ADDRESS_0);
 	if (!io_base_addr)
 		return 1;
 
@@ -265,6 +273,12 @@ int nicintel_spi_init(void)
 		nicintel_spibar = rphysmap("Intel Gigabit NIC w/ SPI flash", io_base_addr,
 					   MEMMAP_SIZE);
 		if (!nicintel_spibar || nicintel_spi_82599_enable_flash())
+				return 1;
+	} else if ((dev->device_id & 0xfff0) == 0x1510 ||
+			(dev->device_id & 0xfff0) == 0x1520) {
+		nicintel_spibar = rphysmap("Intel I350 Gigabit w/ SPI flash", io_base_addr,
+					   MEMMAP_SIZE);
+		if (!nicintel_spibar || nicintel_spi_i210_enable_flash())
 				return 1;
 	} else {
 		nicintel_spibar = rphysmap("Intel 10 Gigabit NIC w/ SPI flash", io_base_addr + 0x10000,


### PR DESCRIPTION
While trying to flash I350 Intel NIC's on arm64 linux I had to change
some things to make it work well

Change-Id: Id203d2ce247cf39a8d650887322ccced0151c6a9
Signed-off-by: Martijn Berger <martijn.berger@gmail.com>